### PR TITLE
Formatted Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ const App = () => {
     editor?.addRectangle()
   }
 
-  return (<div>
-    <button onClick={onAddCircle}>Add circle</button>
-    <button onClick={onAddRectangle}>Add Rectangle</button>
-    <FabricJSCanvas className="sample-canvas" onReady={onReady} />
-  </div>)
+  return (
+    <div>
+      <button onClick={onAddCircle}>Add circle</button>
+      <button onClick={onAddRectangle}>Add Rectangle</button>
+      <FabricJSCanvas className="sample-canvas" onReady={onReady} />
+    </div>
+  )
 }
 
 export default App


### PR DESCRIPTION
Simply fixes the indentation of the return statement on the first code example.  
It just bothered my OCD mind a bit.

Have a Nice Day!