### PR TITLE
fix: adjust exports field for TypeScript typings resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "exports": {
     ".": {
       "import": "./dist/fabricjs-react.es.js",
-      "require": "./dist/fabricjs-react.umd.js"
+      "require": "./dist/fabricjs-react.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
TypeScript was unable to resolve the module's typings when respecting the package.json "exports" field. This change ensures that TypeScript can correctly point to the `index.d.ts` file for types.

Related to issue #35 
